### PR TITLE
Remove a layer of indirection while iterating using `flatten()`

### DIFF
--- a/src/poker/game.rs
+++ b/src/poker/game.rs
@@ -392,8 +392,7 @@ impl<T> Game<T> {
     fn is_ready_for_showdown(&self) -> bool {
         let mut num_players_remaining: usize = 0;
         let mut num_all_in: usize = 0;
-        for seat in self.data.seats.iter() {
-            if let Some(player) = seat {
+        for player in self.data.seats.iter().flatten() {
                 match player.state {
                     PlayerState::AllIn => {
                         num_players_remaining += 1;
@@ -401,7 +400,6 @@ impl<T> Game<T> {
                     }
                     PlayerState::Wait => num_players_remaining += 1,
                     _ => {}
-                }
             }
         }
         // If no one else is left to make a move, then proceed to the showdown.
@@ -1178,14 +1176,12 @@ impl From<Game<UpdateBlinds>> for Game<BootPlayers> {
 
 impl From<Game<BootPlayers>> for Game<SeatPlayers> {
     fn from(mut value: Game<BootPlayers>) -> Self {
-        for seat in value.data.seats.iter_mut() {
-            if let Some(player) = seat {
+        for player in value.data.seats.iter_mut().flatten() {
                 let user = value.data.users.get(&player.name).unwrap();
                 if user.money < value.data.big_blind {
                     value.data.players_to_spectate.insert(player.name.clone());
                 } else {
                     player.reset();
-                }
             }
         }
         while let Some(username) = value.data.players_to_spectate.pop_first() {


### PR DESCRIPTION
If you want to skip over `None` values while iterating, `flatten()` is a way to do that.  Or you could use `filter(Option::is_some)` in this case, but `flatten()` is less typing.